### PR TITLE
enable vipsAffine to use  `Extend` option value and send it to lipvips

### DIFF
--- a/resizer.go
+++ b/resizer.go
@@ -216,7 +216,7 @@ func transformImage(image *C.VipsImage, o Options, shrink int, residual float64)
 		if residualx < 1 && residualy < 1 {
 			image, err = vipsReduce(image, 1/residualx, 1/residualy)
 		} else {
-			image, err = vipsAffine(image, residualx, residualy, o.Interpolator)
+			image, err = vipsAffine(image, residualx, residualy, o.Interpolator, o.Extend)
 		}
 		if err != nil {
 			return nil, err

--- a/vips.go
+++ b/vips.go
@@ -595,7 +595,11 @@ func vipsEmbed(input *C.VipsImage, left, top, width, height int, extend Extend, 
 	return image, nil
 }
 
-func vipsAffine(input *C.VipsImage, residualx, residualy float64, i Interpolator) (*C.VipsImage, error) {
+func vipsAffine(input *C.VipsImage, residualx, residualy float64, i Interpolator, extend Extend) (*C.VipsImage, error) {
+	if extend > 5 {
+		extend = ExtendBackground
+	}
+
 	var image *C.VipsImage
 	cstring := C.CString(i.String())
 	interpolator := C.vips_interpolate_new(cstring)
@@ -604,7 +608,7 @@ func vipsAffine(input *C.VipsImage, residualx, residualy float64, i Interpolator
 	defer C.g_object_unref(C.gpointer(input))
 	defer C.g_object_unref(C.gpointer(interpolator))
 
-	err := C.vips_affine_interpolator(input, &image, C.double(residualx), 0, 0, C.double(residualy), interpolator)
+	err := C.vips_affine_interpolator(input, &image, C.double(residualx), 0, 0, C.double(residualy), interpolator, C.int(extend))
 	if err != 0 {
 		return nil, catchVipsError()
 	}

--- a/vips.h
+++ b/vips.h
@@ -102,8 +102,8 @@ vips_enable_cache_set_trace() {
 }
 
 int
-vips_affine_interpolator(VipsImage *in, VipsImage **out, double a, double b, double c, double d, VipsInterpolate *interpolator) {
-	return vips_affine(in, out, a, b, c, d, "interpolate", interpolator, NULL);
+vips_affine_interpolator(VipsImage *in, VipsImage **out, double a, double b, double c, double d, VipsInterpolate *interpolator, int extend) {
+	return vips_affine(in, out, a, b, c, d, "interpolate", interpolator, "extend", extend, NULL);
 }
 
 int


### PR DESCRIPTION
this will change the default from the one that lipvips use which is `background` to the ones that bimg use which is  `C.VIPS_EXTEND_BLACK`
but because the lip add extra 1 or .5 pix the background is considered black anyway so this will not affect anyone
but will fix the bug of having border on the right and bottom of some images

[ch15924]